### PR TITLE
Comments: Make REST comment moderation comment-type aware (Trac #35214, Stage 3)

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-comments-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-comments-controller.php
@@ -139,6 +139,14 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 						array( 'status' => rest_authorization_required_code() )
 					);
 				} elseif ( 0 === $post_id && ! current_user_can( 'moderate_comments' ) ) {
+					/*
+					 * Intentionally the global primitive: this gates the whole ?post=0
+					 * collection, which can mix comment types, before any individual
+					 * comment is known. Known divergence: a global moderator sees
+					 * independent-type orphans filtered out of the list (empty 200)
+					 * while a type moderator gets 403 here. A per-type collection
+					 * treatment belongs with a future `type` parameter rework.
+					 */
 					return new WP_Error(
 						'rest_cannot_read',
 						__( 'Sorry, you are not allowed to read comments without a post.' ),
@@ -190,6 +198,8 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 				}
 			}
 		} elseif ( $is_edit_context && ! current_user_can( 'moderate_comments' ) ) {
+			// Intentionally the global primitive: gates an edit-context collection
+			// that can mix comment types, before any individual comment is known.
 			return new WP_Error(
 				'rest_forbidden_context',
 				__( 'Sorry, you are not allowed to edit comments.' ),
@@ -437,8 +447,13 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 			return $comment;
 		}
 
-		// Re-map edit context capabilities when requesting `note` type.
-		$edit_cap = 'note' === $comment->comment_type ? array( 'edit_comment', $comment->comment_ID ) : array( 'moderate_comments' );
+		/*
+		 * Re-map edit context capabilities per comment type: `note` comments are
+		 * gated by `edit_comment`, all others by the per-comment `moderate_comment`
+		 * meta capability. This matches the update and delete paths, whose responses
+		 * already return edit-context data.
+		 */
+		$edit_cap = 'note' === $comment->comment_type ? array( 'edit_comment', $comment->comment_ID ) : array( 'moderate_comment', $comment->comment_ID );
 		if ( ! empty( $request['context'] ) && 'edit' === $request['context'] && ! current_user_can( ...$edit_cap ) ) {
 			return new WP_Error(
 				'rest_forbidden_context',
@@ -539,7 +554,12 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 			}
 		}
 
-		// Limit who can set comment `author`, `author_ip` or `status` to anything other than the default.
+		/*
+		 * Limit who can set comment `author`, `author_ip` or `status` to anything
+		 * other than the default. Intentionally the global primitive: these gates
+		 * run at creation time, and honoring the (known) type's own moderation
+		 * primitive here is future work alongside the other creation-time gates.
+		 */
 		if ( isset( $request['author'] ) && get_current_user_id() !== $request['author'] && ! current_user_can( 'moderate_comments' ) ) {
 			return new WP_Error(
 				'rest_comment_invalid_author',
@@ -1913,6 +1933,8 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 	 * Checks if the comment can be read.
 	 *
 	 * @since 4.7.0
+	 * @since 7.1.0 Orphaned comments are gated by the per-comment `moderate_comment`
+	 *              meta capability instead of the global `moderate_comments` primitive.
 	 *
 	 * @param WP_Comment      $comment Comment object.
 	 * @param WP_REST_Request $request Request data to check.
@@ -1947,6 +1969,8 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 	 * Checks if a comment can be edited or deleted.
 	 *
 	 * @since 4.7.0
+	 * @since 7.1.0 Uses the per-comment `moderate_comment` meta capability instead
+	 *              of the global `moderate_comments` primitive.
 	 *
 	 * @param WP_Comment $comment Comment object.
 	 * @return bool Whether the comment can be edited or deleted.

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-comments-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-comments-controller.php
@@ -1932,7 +1932,7 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 			return false;
 		}
 
-		if ( empty( $comment->comment_post_ID ) && ! current_user_can( 'moderate_comments' ) ) {
+		if ( empty( $comment->comment_post_ID ) && ! current_user_can( 'moderate_comment', $comment->comment_ID ) ) {
 			return false;
 		}
 
@@ -1956,7 +1956,13 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 			return false;
 		}
 
-		if ( current_user_can( 'moderate_comments' ) ) {
+		/*
+		 * Use the per-comment `moderate_comment` meta capability rather than the
+		 * global `moderate_comments` primitive. For comment types using the default
+		 * capability model this resolves to `moderate_comments` (unchanged), while a
+		 * type with its own capabilities is gated by its own moderation primitive.
+		 */
+		if ( current_user_can( 'moderate_comment', $comment->comment_ID ) ) {
 			return true;
 		}
 

--- a/tests/phpunit/tests/rest-api/rest-comment-type-moderation.php
+++ b/tests/phpunit/tests/rest-api/rest-comment-type-moderation.php
@@ -11,8 +11,10 @@
  * @group capabilities
  *
  * @covers WP_REST_Comments_Controller::check_edit_permission
+ * @covers WP_REST_Comments_Controller::check_read_permission
+ * @covers WP_REST_Comments_Controller::get_item_permissions_check
  */
-class Tests_REST_Comment_Type_Moderation extends WP_UnitTestCase {
+class Tests_REST_Comment_Type_Moderation extends WP_Test_REST_TestCase {
 
 	/**
 	 * Post the comments are attached to.
@@ -20,6 +22,13 @@ class Tests_REST_Comment_Type_Moderation extends WP_UnitTestCase {
 	 * @var int
 	 */
 	protected static $post_id;
+
+	/**
+	 * Administrator user ID (moderate_comments plus edit_posts).
+	 *
+	 * @var int
+	 */
+	protected static $admin_id;
 
 	/**
 	 * User with the global `moderate_comments` primitive only.
@@ -43,7 +52,8 @@ class Tests_REST_Comment_Type_Moderation extends WP_UnitTestCase {
 	protected static $review_editor_id;
 
 	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
-		self::$post_id = $factory->post->create();
+		self::$post_id  = $factory->post->create();
+		self::$admin_id = $factory->user->create( array( 'role' => 'administrator' ) );
 
 		self::$global_moderator_id = $factory->user->create( array( 'role' => 'subscriber' ) );
 		get_userdata( self::$global_moderator_id )->add_cap( 'moderate_comments' );
@@ -62,22 +72,18 @@ class Tests_REST_Comment_Type_Moderation extends WP_UnitTestCase {
 		register_comment_type( 'review', array( 'capability_type' => 'review' ) );
 	}
 
-	public function tear_down() {
-		unregister_comment_type( 'review' );
-
-		parent::tear_down();
-	}
-
 	/**
 	 * Creates a comment of the given type on the shared post.
 	 *
 	 * @param string $comment_type Comment type slug.
+	 * @param int    $post_id      Optional. Post to attach the comment to; 0 for an
+	 *                             orphaned comment. Default the shared post.
 	 * @return int The new comment ID.
 	 */
-	private function make_comment( $comment_type ) {
+	private function make_comment( $comment_type, $post_id = null ) {
 		return self::factory()->comment->create(
 			array(
-				'comment_post_ID'  => self::$post_id,
+				'comment_post_ID'  => null === $post_id ? self::$post_id : $post_id,
 				'comment_type'     => $comment_type,
 				'comment_approved' => '1',
 			)
@@ -106,6 +112,20 @@ class Tests_REST_Comment_Type_Moderation extends WP_UnitTestCase {
 	private function dispatch_delete( $comment_id ) {
 		$request = new WP_REST_Request( 'DELETE', '/wp/v2/comments/' . $comment_id );
 		$request->set_param( 'force', true );
+
+		return rest_get_server()->dispatch( $request );
+	}
+
+	/**
+	 * Dispatches a REST request to read a single comment.
+	 *
+	 * @param int    $comment_id Comment to read.
+	 * @param string $context    Optional. Request context. Default 'view'.
+	 * @return WP_REST_Response
+	 */
+	private function dispatch_get( $comment_id, $context = 'view' ) {
+		$request = new WP_REST_Request( 'GET', '/wp/v2/comments/' . $comment_id );
+		$request->set_param( 'context', $context );
 
 		return rest_get_server()->dispatch( $request );
 	}
@@ -160,7 +180,7 @@ class Tests_REST_Comment_Type_Moderation extends WP_UnitTestCase {
 
 		$response = $this->dispatch_update( $this->make_comment( 'review' ) );
 
-		$this->assertSame( 403, $response->get_status() );
+		$this->assertErrorResponse( 'rest_cannot_edit', $response, 403 );
 	}
 
 	/**
@@ -171,7 +191,7 @@ class Tests_REST_Comment_Type_Moderation extends WP_UnitTestCase {
 
 		$response = $this->dispatch_delete( $this->make_comment( 'review' ) );
 
-		$this->assertSame( 403, $response->get_status() );
+		$this->assertErrorResponse( 'rest_cannot_delete', $response, 403 );
 	}
 
 	/**
@@ -184,7 +204,7 @@ class Tests_REST_Comment_Type_Moderation extends WP_UnitTestCase {
 
 		$response = $this->dispatch_update( $this->make_comment( 'comment' ) );
 
-		$this->assertSame( 403, $response->get_status() );
+		$this->assertErrorResponse( 'rest_cannot_edit', $response, 403 );
 	}
 
 	/*
@@ -224,5 +244,174 @@ class Tests_REST_Comment_Type_Moderation extends WP_UnitTestCase {
 		$response = $this->dispatch_update( $this->make_comment( 'pingback' ) );
 
 		$this->assertSame( 200, $response->get_status() );
+	}
+
+	/**
+	 * An UNREGISTERED comment type stays fully moderatable by a global moderator.
+	 *
+	 * This pins the back-compat fallback everything relies on: comments of types
+	 * that were never registered (e.g. stored by plugins before registration
+	 * existed, or after their plugin is deactivated) resolve to a null type
+	 * object and behave exactly like default comments.
+	 *
+	 * @ticket 35214
+	 */
+	public function test_global_moderator_retains_control_over_unregistered_type() {
+		wp_set_current_user( self::$global_moderator_id );
+
+		$webmention_id = $this->make_comment( 'webmention' );
+
+		$response = $this->dispatch_update( $webmention_id );
+		$this->assertSame( 200, $response->get_status(), 'A global moderator should be able to update an unregistered-type comment.' );
+
+		$response = $this->dispatch_delete( $webmention_id );
+		$this->assertSame( 200, $response->get_status(), 'A global moderator should be able to delete an unregistered-type comment.' );
+	}
+
+	/**
+	 * A comment stored with the legacy empty string type behaves like a default comment.
+	 *
+	 * @ticket 35214
+	 */
+	public function test_global_moderator_can_update_legacy_empty_type_comment() {
+		wp_set_current_user( self::$global_moderator_id );
+
+		$response = $this->dispatch_update( $this->make_comment( '' ) );
+
+		$this->assertSame( 200, $response->get_status() );
+	}
+
+	/*
+	 * Single-item edit-context reads (get_item_permissions_check()): the read gate
+	 * matches the update/delete gates, whose responses already return edit data.
+	 */
+
+	/**
+	 * @ticket 35214
+	 */
+	public function test_review_moderator_can_read_review_comment_in_edit_context() {
+		wp_set_current_user( self::$review_moderator_id );
+
+		$response = $this->dispatch_get( $this->make_comment( 'review' ), 'edit' );
+
+		$this->assertSame( 200, $response->get_status() );
+	}
+
+	/**
+	 * @ticket 35214
+	 */
+	public function test_global_moderator_cannot_read_review_comment_in_edit_context() {
+		wp_set_current_user( self::$global_moderator_id );
+
+		$response = $this->dispatch_get( $this->make_comment( 'review' ), 'edit' );
+
+		$this->assertErrorResponse( 'rest_forbidden_context', $response, 403 );
+	}
+
+	/**
+	 * @ticket 35214
+	 */
+	public function test_global_moderator_can_read_default_comment_in_edit_context() {
+		wp_set_current_user( self::$global_moderator_id );
+
+		$response = $this->dispatch_get( $this->make_comment( 'comment' ), 'edit' );
+
+		$this->assertSame( 200, $response->get_status() );
+	}
+
+	/*
+	 * Orphaned comments (comment_post_ID = 0) through check_read_permission().
+	 */
+
+	/**
+	 * Reading an orphaned default comment requires passing both the orphan gate
+	 * (moderate_comment) and the final edit_comment check, which for orphans
+	 * falls back to edit_posts - so administrators pass and bare moderators do
+	 * not, exactly as before this change.
+	 *
+	 * @ticket 35214
+	 */
+	public function test_admin_can_read_orphaned_default_comment() {
+		wp_set_current_user( self::$admin_id );
+
+		$response = $this->dispatch_get( $this->make_comment( 'comment', 0 ) );
+
+		$this->assertSame( 200, $response->get_status() );
+	}
+
+	/**
+	 * @ticket 35214
+	 */
+	public function test_subscriber_cannot_read_orphaned_default_comment() {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'subscriber' ) ) );
+
+		$response = $this->dispatch_get( $this->make_comment( 'comment', 0 ) );
+
+		$this->assertErrorResponse( 'rest_cannot_read', $response, 403 );
+	}
+
+	/**
+	 * Reading an orphaned independent-type comment requires the type's own
+	 * capabilities on both checks: its moderation primitive for the orphan gate
+	 * and its edit primitives for the final edit_comment check.
+	 *
+	 * @ticket 35214
+	 */
+	public function test_review_moderator_with_edit_cap_can_read_orphaned_review_comment() {
+		$full_review_moderator = self::factory()->user->create_and_get( array( 'role' => 'subscriber' ) );
+		$full_review_moderator->add_cap( 'moderate_reviews' );
+		$full_review_moderator->add_cap( 'edit_others_reviews' );
+
+		wp_set_current_user( $full_review_moderator->ID );
+
+		$response = $this->dispatch_get( $this->make_comment( 'review', 0 ) );
+
+		$this->assertSame( 200, $response->get_status() );
+	}
+
+	/**
+	 * Even an administrator (global moderate_comments and edit_posts) cannot
+	 * read an orphaned comment of an independent type.
+	 *
+	 * @ticket 35214
+	 */
+	public function test_admin_cannot_read_orphaned_review_comment() {
+		wp_set_current_user( self::$admin_id );
+
+		$response = $this->dispatch_get( $this->make_comment( 'review', 0 ) );
+
+		$this->assertErrorResponse( 'rest_cannot_read', $response, 403 );
+	}
+
+	/**
+	 * The `?post=0` collection gate stays on the global primitive: a global
+	 * moderator gets the list with independent-type orphans filtered out, while
+	 * a type moderator is rejected at the gate. This pins the known, documented
+	 * divergence until a per-type collection treatment exists.
+	 *
+	 * @ticket 35214
+	 */
+	public function test_orphan_collection_gate_uses_global_primitive() {
+		$default_orphan = $this->make_comment( 'comment', 0 );
+		$review_orphan  = $this->make_comment( 'review', 0 );
+
+		wp_set_current_user( self::$admin_id );
+
+		$request = new WP_REST_Request( 'GET', '/wp/v2/comments' );
+		$request->set_param( 'post', 0 );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+		$ids = wp_list_pluck( $response->get_data(), 'id' );
+		$this->assertContains( $default_orphan, $ids, 'The default-type orphan should be listed for an administrator.' );
+		$this->assertNotContains( $review_orphan, $ids, 'The independent-type orphan should be filtered out for an administrator.' );
+
+		wp_set_current_user( self::$review_moderator_id );
+
+		$request = new WP_REST_Request( 'GET', '/wp/v2/comments' );
+		$request->set_param( 'post', 0 );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertErrorResponse( 'rest_cannot_read', $response, 403 );
 	}
 }

--- a/tests/phpunit/tests/rest-api/rest-comment-type-moderation.php
+++ b/tests/phpunit/tests/rest-api/rest-comment-type-moderation.php
@@ -1,0 +1,228 @@
+<?php
+/**
+ * Integration tests for per-comment-type moderation in the REST comments controller.
+ *
+ * Exercises the `check_edit_permission()` gate end to end: a comment type with an
+ * independent capability model is moderated through its own primitives, while the
+ * default capability model behaves exactly as before.
+ *
+ * @group restapi
+ * @group comment
+ * @group capabilities
+ *
+ * @covers WP_REST_Comments_Controller::check_edit_permission
+ */
+class Tests_REST_Comment_Type_Moderation extends WP_UnitTestCase {
+
+	/**
+	 * Post the comments are attached to.
+	 *
+	 * @var int
+	 */
+	protected static $post_id;
+
+	/**
+	 * User with the global `moderate_comments` primitive only.
+	 *
+	 * @var int
+	 */
+	protected static $global_moderator_id;
+
+	/**
+	 * User with the `review` type's `moderate_reviews` primitive only.
+	 *
+	 * @var int
+	 */
+	protected static $review_moderator_id;
+
+	/**
+	 * User with the `review` type's `edit_others_reviews` primitive only.
+	 *
+	 * @var int
+	 */
+	protected static $review_editor_id;
+
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		self::$post_id = $factory->post->create();
+
+		self::$global_moderator_id = $factory->user->create( array( 'role' => 'subscriber' ) );
+		get_userdata( self::$global_moderator_id )->add_cap( 'moderate_comments' );
+
+		self::$review_moderator_id = $factory->user->create( array( 'role' => 'subscriber' ) );
+		get_userdata( self::$review_moderator_id )->add_cap( 'moderate_reviews' );
+
+		self::$review_editor_id = $factory->user->create( array( 'role' => 'subscriber' ) );
+		get_userdata( self::$review_editor_id )->add_cap( 'edit_others_reviews' );
+	}
+
+	public function set_up() {
+		parent::set_up();
+
+		// A comment type with an independent capability model.
+		register_comment_type( 'review', array( 'capability_type' => 'review' ) );
+	}
+
+	public function tear_down() {
+		unregister_comment_type( 'review' );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Creates a comment of the given type on the shared post.
+	 *
+	 * @param string $comment_type Comment type slug.
+	 * @return int The new comment ID.
+	 */
+	private function make_comment( $comment_type ) {
+		return self::factory()->comment->create(
+			array(
+				'comment_post_ID'  => self::$post_id,
+				'comment_type'     => $comment_type,
+				'comment_approved' => '1',
+			)
+		);
+	}
+
+	/**
+	 * Dispatches a REST request to update a comment's content.
+	 *
+	 * @param int $comment_id Comment to update.
+	 * @return WP_REST_Response
+	 */
+	private function dispatch_update( $comment_id ) {
+		$request = new WP_REST_Request( 'POST', '/wp/v2/comments/' . $comment_id );
+		$request->set_param( 'content', 'Updated content' );
+
+		return rest_get_server()->dispatch( $request );
+	}
+
+	/**
+	 * Dispatches a REST request to force-delete a comment.
+	 *
+	 * @param int $comment_id Comment to delete.
+	 * @return WP_REST_Response
+	 */
+	private function dispatch_delete( $comment_id ) {
+		$request = new WP_REST_Request( 'DELETE', '/wp/v2/comments/' . $comment_id );
+		$request->set_param( 'force', true );
+
+		return rest_get_server()->dispatch( $request );
+	}
+
+	/*
+	 * Independent capability model.
+	 */
+
+	/**
+	 * @ticket 35214
+	 */
+	public function test_review_moderator_can_update_review_comment() {
+		wp_set_current_user( self::$review_moderator_id );
+
+		$response = $this->dispatch_update( $this->make_comment( 'review' ) );
+
+		$this->assertSame( 200, $response->get_status() );
+	}
+
+	/**
+	 * @ticket 35214
+	 */
+	public function test_review_moderator_can_delete_review_comment() {
+		wp_set_current_user( self::$review_moderator_id );
+
+		$response = $this->dispatch_delete( $this->make_comment( 'review' ) );
+
+		$this->assertSame( 200, $response->get_status() );
+	}
+
+	/**
+	 * The type's `edit_others_reviews` primitive also grants moderation through the
+	 * `edit_comment` fallback in `check_edit_permission()`.
+	 *
+	 * @ticket 35214
+	 */
+	public function test_review_editor_can_update_review_comment() {
+		wp_set_current_user( self::$review_editor_id );
+
+		$response = $this->dispatch_update( $this->make_comment( 'review' ) );
+
+		$this->assertSame( 200, $response->get_status() );
+	}
+
+	/**
+	 * A global `moderate_comments` moderator has no power over an independent type.
+	 *
+	 * @ticket 35214
+	 */
+	public function test_global_moderator_cannot_update_review_comment() {
+		wp_set_current_user( self::$global_moderator_id );
+
+		$response = $this->dispatch_update( $this->make_comment( 'review' ) );
+
+		$this->assertSame( 403, $response->get_status() );
+	}
+
+	/**
+	 * @ticket 35214
+	 */
+	public function test_global_moderator_cannot_delete_review_comment() {
+		wp_set_current_user( self::$global_moderator_id );
+
+		$response = $this->dispatch_delete( $this->make_comment( 'review' ) );
+
+		$this->assertSame( 403, $response->get_status() );
+	}
+
+	/**
+	 * A review moderator has no power over a default-model comment.
+	 *
+	 * @ticket 35214
+	 */
+	public function test_review_moderator_cannot_update_default_comment() {
+		wp_set_current_user( self::$review_moderator_id );
+
+		$response = $this->dispatch_update( $this->make_comment( 'comment' ) );
+
+		$this->assertSame( 403, $response->get_status() );
+	}
+
+	/*
+	 * Default capability model: unchanged from historical behavior.
+	 */
+
+	/**
+	 * @ticket 35214
+	 */
+	public function test_global_moderator_can_update_default_comment() {
+		wp_set_current_user( self::$global_moderator_id );
+
+		$response = $this->dispatch_update( $this->make_comment( 'comment' ) );
+
+		$this->assertSame( 200, $response->get_status() );
+	}
+
+	/**
+	 * @ticket 35214
+	 */
+	public function test_global_moderator_can_delete_default_comment() {
+		wp_set_current_user( self::$global_moderator_id );
+
+		$response = $this->dispatch_delete( $this->make_comment( 'comment' ) );
+
+		$this->assertSame( 200, $response->get_status() );
+	}
+
+	/**
+	 * The built-in pingback type uses the default model and is unaffected.
+	 *
+	 * @ticket 35214
+	 */
+	public function test_global_moderator_can_update_builtin_ping_comment() {
+		wp_set_current_user( self::$global_moderator_id );
+
+		$response = $this->dispatch_update( $this->make_comment( 'pingback' ) );
+
+		$this->assertSame( 200, $response->get_status() );
+	}
+}


### PR DESCRIPTION
## Summary

**Stage 3** of capability enforcement (follow-up to [PR #55](https://github.com/adamsilverstein/wordpress-develop/pull/55)): start rerouting real moderation call sites through the new `moderate_comment` meta capability, beginning with the **REST API** - the cleanest, most self-contained, most testable surface.

`WP_REST_Comments_Controller::check_edit_permission()` (the gate for REST update **and** delete) short-circuited on the global `moderate_comments` primitive:

```php
if ( current_user_can( 'moderate_comments' ) ) {
    return true;
}
return current_user_can( 'edit_comment', $comment->comment_ID );
```

That had two problems for a comment type with an independent capability model: a moderator of that type (holding e.g. `moderate_reviews`) could **not** act on its comments, while any global moderator could act on **every** type regardless of its model.

## What changed

One-line semantic change in two spots: route the moderator shortcut through the per-comment `moderate_comment` meta cap (added in #55) instead of the global primitive.

- `check_edit_permission()` - the update/delete gate.
- `check_read_permission()` - the orphaned-comment branch.

For the default capability model `moderate_comment` resolves to `moderate_comments`, so **built-in `comment` / `pingback` / `trackback` / `note` are completely unchanged**. A type with its own `capability_type` is gated by its own moderation primitive.

## Why this is the whole REST surface (mostly)

Most per-comment REST gates already call `current_user_can( 'edit_comment', $id )`, which #55 made type-aware - so they needed no change. The remaining bare `moderate_comments` checks in the controller are **cross-cutting / field-level** (collection edit context, setting `author` / `author_ip`), where per-single-comment semantics don't apply; those are intentionally left as the global primitive.

## Testing

New `tests/phpunit/tests/rest-api/rest-comment-type-moderation.php` dispatches real `POST` (update) and `DELETE` requests:
- A `review` moderator (`moderate_reviews`) **and** a `review` editor (`edit_others_reviews`) can update/delete review comments.
- A global `moderate_comments` moderator gets **403** on review comments (independence proven at the REST layer) - and a review moderator gets **403** on default comments (the inverse).
- Default comments, and the built-in `pingback` type, still update/delete fine for a global moderator (back-compat).

Full `--group comment --group capabilities --group restapi` passes (the only failure is a pre-existing environmental oEmbed flake unrelated to comments). PHPCS + PHPStan clean.

## Review updates

- The review found one per-comment moderation gate this PR originally missed: `get_item_permissions_check()` still used the global primitive for edit-context reads of non-note comments, so a type moderator could update or delete a comment but got a 403 reading it with `?context=edit`. It is now routed through the per-comment meta cap (`current_user_can( 'moderate_comment', $comment->comment_ID )`) to match the update/delete paths.
- Known divergence, documented in an inline comment and pinned by a test: the `?post=0` orphan **collection** gate intentionally stays on the global `moderate_comments` primitive, since it gates a mixed-type collection before any specific comment is known. The result: a global moderator sees independent-type orphans filtered out of the list, while a type moderator is rejected at the gate. A real fix belongs with a future type-parameter rework of the collection endpoint.
- New tests: the unregistered-type back-compat pin (a global moderator keeps full control over never-registered types - the null-type-object fallback), legacy empty-string types, single-item edit-context reads under each capability model, orphaned reads under both models, and error-code assertions via `assertErrorResponse()`.

## Remaining Stage 3 families (future PRs)

Same pattern, one focused PR each so every surface gets its own security review: admin (`wp-admin/comment.php` is already `edit_comment`-gated; list-table bulk/`ajax-actions.php` moderation fallback at line 1000), and XML-RPC (`wp.editComment` status change). These reach the same `map_meta_cap()` foundation.

## Stacking

Based on `feature/comment-type-cap-enforcement` ([#55](https://github.com/adamsilverstein/wordpress-develop/pull/55)). Retarget to `trunk` as the stack lands behind [#12311](https://github.com/WordPress/wordpress-develop/pull/12311).

See #35214.
