### PR TITLE
Comments: Make admin comment dimming comment-type aware (Trac #35214, Stage 3)

### DIFF
--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -997,7 +997,7 @@ function wp_ajax_dim_comment() {
 		$response->send();
 	}
 
-	if ( ! current_user_can( 'edit_comment', $comment->comment_ID ) && ! current_user_can( 'moderate_comments' ) ) {
+	if ( ! current_user_can( 'edit_comment', $comment->comment_ID ) && ! current_user_can( 'moderate_comment', $comment->comment_ID ) ) {
 		wp_die( -1 );
 	}
 

--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -978,6 +978,8 @@ function wp_ajax_delete_page( $action ) {
  * Handles dimming a comment via AJAX.
  *
  * @since 3.1.0
+ * @since 7.1.0 Uses the per-comment `moderate_comment` meta capability instead
+ *              of the global `moderate_comments` primitive.
  */
 function wp_ajax_dim_comment() {
 	$id      = isset( $_POST['id'] ) ? (int) $_POST['id'] : 0;
@@ -997,6 +999,12 @@ function wp_ajax_dim_comment() {
 		$response->send();
 	}
 
+	/*
+	 * Use the per-comment `moderate_comment` meta capability: it resolves to the
+	 * global `moderate_comments` primitive for default-model and unregistered
+	 * types (unchanged), and to the type's own moderation primitive for a
+	 * registered type with its own capabilities.
+	 */
 	if ( ! current_user_can( 'edit_comment', $comment->comment_ID ) && ! current_user_can( 'moderate_comment', $comment->comment_ID ) ) {
 		wp_die( -1 );
 	}

--- a/tests/phpunit/tests/ajax/wpAjaxDimComment.php
+++ b/tests/phpunit/tests/ajax/wpAjaxDimComment.php
@@ -45,12 +45,6 @@ class Tests_Ajax_wpAjaxDimComment extends WP_Ajax_UnitTestCase {
 		register_comment_type( 'review', array( 'capability_type' => 'review' ) );
 	}
 
-	public function tear_down() {
-		unregister_comment_type( 'review' );
-
-		parent::tear_down();
-	}
-
 	/**
 	 * Clears the POST actions in between requests.
 	 */
@@ -329,5 +323,72 @@ class Tests_Ajax_wpAjaxDimComment extends WP_Ajax_UnitTestCase {
 		$this->expectException( 'WPAjaxDieStopException' );
 		$this->expectExceptionMessage( '-1' );
 		$this->_handleAjax( 'dim-comment' );
+	}
+
+	/**
+	 * A type moderator can also un-dim: dimming an approved comment unapproves it.
+	 *
+	 * @ticket 35214
+	 */
+	public function test_dim_approved_review_comment_as_type_moderator_unapproves_it() {
+		$comment_id = $this->make_comment( 'review' );
+		wp_set_comment_status( $comment_id, 'approve' );
+
+		$moderator = self::factory()->user->create_and_get( array( 'role' => 'subscriber' ) );
+		$moderator->add_cap( 'moderate_reviews' );
+		wp_set_current_user( $moderator->ID );
+
+		$this->set_up_dim_request( $comment_id );
+
+		try {
+			$this->_handleAjax( 'dim-comment' );
+		} catch ( WPAjaxDieContinueException $e ) {
+			unset( $e );
+		}
+
+		$this->assertSame( 'unapproved', wp_get_comment_status( $comment_id ) );
+	}
+
+	/**
+	 * The inverse denial: a type moderator cannot dim a default-model comment.
+	 *
+	 * @ticket 35214
+	 */
+	public function test_dim_default_comment_as_type_moderator_is_denied() {
+		$comment_id = $this->make_comment( 'comment' );
+
+		$moderator = self::factory()->user->create_and_get( array( 'role' => 'subscriber' ) );
+		$moderator->add_cap( 'moderate_reviews' );
+		wp_set_current_user( $moderator->ID );
+
+		$this->set_up_dim_request( $comment_id );
+
+		$this->expectException( 'WPAjaxDieStopException' );
+		$this->expectExceptionMessage( '-1' );
+		$this->_handleAjax( 'dim-comment' );
+	}
+
+	/**
+	 * A global moderator keeps full control over UNREGISTERED comment types
+	 * (the null type object back-compat fallback).
+	 *
+	 * @ticket 35214
+	 */
+	public function test_dim_unregistered_type_comment_as_global_moderator_is_allowed() {
+		$comment_id = $this->make_comment( 'webmention' );
+
+		$global_moderator = self::factory()->user->create_and_get( array( 'role' => 'subscriber' ) );
+		$global_moderator->add_cap( 'moderate_comments' );
+		wp_set_current_user( $global_moderator->ID );
+
+		$this->set_up_dim_request( $comment_id );
+
+		try {
+			$this->_handleAjax( 'dim-comment' );
+		} catch ( WPAjaxDieContinueException $e ) {
+			unset( $e );
+		}
+
+		$this->assertSame( 'approved', wp_get_comment_status( $comment_id ) );
 	}
 }

--- a/tests/phpunit/tests/ajax/wpAjaxDimComment.php
+++ b/tests/phpunit/tests/ajax/wpAjaxDimComment.php
@@ -26,13 +26,29 @@ class Tests_Ajax_wpAjaxDimComment extends WP_Ajax_UnitTestCase {
 	protected $_comments = array();
 
 	/**
+	 * Post the comments are attached to.
+	 *
+	 * @var int
+	 */
+	protected $_post_id;
+
+	/**
 	 * Sets up the test fixture.
 	 */
 	public function set_up() {
 		parent::set_up();
-		$post_id         = self::factory()->post->create();
-		$this->_comments = self::factory()->comment->create_post_comments( $post_id, 15 );
+		$this->_post_id  = self::factory()->post->create();
+		$this->_comments = self::factory()->comment->create_post_comments( $this->_post_id, 15 );
 		$this->_comments = array_map( 'get_comment', $this->_comments );
+
+		// A comment type with an independent capability model.
+		register_comment_type( 'review', array( 'capability_type' => 'review' ) );
+	}
+
+	public function tear_down() {
+		unregister_comment_type( 'review' );
+
+		parent::tear_down();
 	}
 
 	/**
@@ -238,5 +254,80 @@ class Tests_Ajax_wpAjaxDimComment extends WP_Ajax_UnitTestCase {
 	public function test_ajax_dim_comment_bad_nonce() {
 		$comment = array_pop( $this->_comments );
 		$this->_test_with_bad_nonce( $comment );
+	}
+
+	/**
+	 * Creates an unapproved comment of a given type on the shared post.
+	 *
+	 * @param string $comment_type Comment type slug.
+	 * @return int The new comment ID.
+	 */
+	private function make_comment( $comment_type ) {
+		return self::factory()->comment->create(
+			array(
+				'comment_post_ID'  => $this->_post_id,
+				'comment_type'     => $comment_type,
+				'comment_approved' => '0',
+			)
+		);
+	}
+
+	/**
+	 * Sets up the dim-comment request for the given comment.
+	 *
+	 * @param int $comment_id Comment to dim.
+	 */
+	private function set_up_dim_request( $comment_id ) {
+		$this->_clear_post_action();
+
+		$_POST['id']          = $comment_id;
+		$_POST['_ajax_nonce'] = wp_create_nonce( 'approve-comment_' . $comment_id );
+		$_POST['_total']      = 1;
+		$_POST['_per_page']   = 100;
+		$_POST['_page']       = 1;
+		$_POST['_url']        = admin_url( 'edit-comments.php' );
+	}
+
+	/**
+	 * A moderator of an independent comment type can dim its comments.
+	 *
+	 * @ticket 35214
+	 */
+	public function test_dim_review_comment_as_type_moderator_is_allowed() {
+		$comment_id = $this->make_comment( 'review' );
+
+		$moderator = self::factory()->user->create_and_get( array( 'role' => 'subscriber' ) );
+		$moderator->add_cap( 'moderate_reviews' );
+		wp_set_current_user( $moderator->ID );
+
+		$this->set_up_dim_request( $comment_id );
+
+		try {
+			$this->_handleAjax( 'dim-comment' );
+		} catch ( WPAjaxDieContinueException $e ) {
+			unset( $e );
+		}
+
+		// The request was authorized, so the unapproved comment was approved.
+		$this->assertSame( 'approved', wp_get_comment_status( $comment_id ) );
+	}
+
+	/**
+	 * A global moderator without the type's capabilities cannot dim its comments.
+	 *
+	 * @ticket 35214
+	 */
+	public function test_dim_review_comment_as_global_moderator_is_denied() {
+		$comment_id = $this->make_comment( 'review' );
+
+		$global_moderator = self::factory()->user->create_and_get( array( 'role' => 'subscriber' ) );
+		$global_moderator->add_cap( 'moderate_comments' );
+		wp_set_current_user( $global_moderator->ID );
+
+		$this->set_up_dim_request( $comment_id );
+
+		$this->expectException( 'WPAjaxDieStopException' );
+		$this->expectExceptionMessage( '-1' );
+		$this->_handleAjax( 'dim-comment' );
 	}
 }


### PR DESCRIPTION
## Summary

Continues **Stage 3** of capability enforcement (follow-up to [PR #56](https://github.com/adamsilverstein/wordpress-develop/pull/56)) with the **admin** call-site family.

`wp_ajax_dim_comment()` (approve/unapprove from the comments list table) gated on:

```php
if ( ! current_user_can( 'edit_comment', $comment->comment_ID ) && ! current_user_can( 'moderate_comments' ) ) {
    wp_die( -1 );
}
```

The `moderate_comments` fallback is the global primitive, so a moderator of a custom comment type could not dim comments of that type.

## What changed

Route the fallback through the per-comment `moderate_comment` meta cap (added in #55):

```php
if ( ! current_user_can( 'edit_comment', $comment->comment_ID ) && ! current_user_can( 'moderate_comment', $comment->comment_ID ) ) {
```

For the default capability model `moderate_comment` resolves to `moderate_comments`, so **built-in types are unchanged**. A type with its own `capability_type` is gated by its own moderation primitive.

## Why this is the last per-comment admin gate

After auditing the admin + XML-RPC surface, this is the only remaining **admin-side per-comment** moderation gate using the bare global primitive:

- `wp-admin/comment.php`, `edit-comments.php`, and the other AJAX comment handlers already gate on `edit_comment`, which [#55](https://github.com/adamsilverstein/wordpress-develop/pull/55) made type-aware.
- The list table's `moderate_comments` checks (`get_bulk_actions()`, the Empty Spam/Trash button) and XML-RPC `wp.getComments` (status filter) are **collection-level**, not a specific comment, so `moderate_comment` doesn't apply - they correctly stay global.

One REST gate was still outstanding when this was first written: `WP_REST_Comments_Controller::get_item_permissions_check()` also used the global primitive for edit-context reads. That gate has since been rerouted in [#56](https://github.com/adamsilverstein/wordpress-develop/pull/56), making this PR's `wp_ajax_dim_comment()` change the remaining admin-side per-comment gate. With both in place, every per-comment moderation gate in core (REST in #56, admin AJAX here) flows through the type-aware `map_meta_cap()` foundation.

## Testing

Extends the existing `wpAjaxDimComment.php` Ajax tests: a `review`-type moderator (`moderate_reviews`) can dim a review comment; a global `moderate_comments` moderator without the type's caps is denied (`-1`). The existing administrator and subscriber tests still pass, confirming the default model is unchanged.

Full `--group ajax --group comment --group capabilities` passes (806 tests). PHPCS + PHPStan clean.

## Review updates

- Added the `@since` entry and an inline comment explaining the reroute rationale.
- New tests cover the un-dim direction (dimming an approved comment unapproves it), the inverse denial (a `review`-type moderator cannot dim a default-model comment), and the unregistered-type back-compat pin via AJAX (a global moderator keeps control over never-registered types).

## Stacking

Based on `feature/comment-type-moderation-rest` ([#56](https://github.com/adamsilverstein/wordpress-develop/pull/56)). Retarget to `trunk` as the stack lands behind [#12311](https://github.com/WordPress/wordpress-develop/pull/12311).

See #35214.
